### PR TITLE
chore: bump version to 0.1.8

### DIFF
--- a/packages/quality-cli/package.json
+++ b/packages/quality-cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tjalve/aiq",
-  "version": "0.1.7",
+  "version": "0.1.8",
   "private": false,
   "type": "module",
   "description": "Code quality pipeline designed for AI agents. Provides consistent, opinionated quality standards to prevent regressions and maintain code tidiness as projects grow. Auto-detects 8+ technologies with staged rollout, pre-commit hooks, and CI/CD integration.",


### PR DESCRIPTION
Bump package version to 0.1.8 to match the release tag and enable publishing.